### PR TITLE
fix(issuer-signed-item): verify digests over received tag-24 bytes

### DIFF
--- a/.changeset/forward-issuer-signed-item-bytes.md
+++ b/.changeset/forward-issuer-signed-item-bytes.md
@@ -1,0 +1,5 @@
+---
+"@owf/mdoc": patch
+---
+
+Forward the issuer's own `IssuerSignedItemBytes` when presenting a credential, instead of re-encoding each item from its decoded structure. A verifier digests the bytes it receives and compares them to `valueDigests`, so re-encoding made genuine claims from other CBOR encoders fail at the verifier.

--- a/.changeset/original-issuer-signed-item-bytes.md
+++ b/.changeset/original-issuer-signed-item-bytes.md
@@ -1,0 +1,5 @@
+---
+"@owf/mdoc": patch
+---
+
+Verify `IssuerSignedItem` digests over the received tag-24 bytes instead of a re-encode, so credentials from other CBOR encoders still pass `isValid`.

--- a/src/mdoc/models/issuer-namespaces.ts
+++ b/src/mdoc/models/issuer-namespaces.ts
@@ -34,9 +34,7 @@ export class IssuerNamespaces extends CborStructure<
         decoded.forEach((value, key) => {
           issuerNamespaces.set(
             key,
-            value.map((isi) =>
-              isi.originalEncoded ? DataItem.fromBuffer(isi.originalEncoded) : DataItem.fromData(isi.encodedStructure)
-            )
+            value.map((isi) => DataItem.fromData(isi.encodedStructure))
           )
         })
         return issuerNamespaces

--- a/src/mdoc/models/issuer-namespaces.ts
+++ b/src/mdoc/models/issuer-namespaces.ts
@@ -1,6 +1,6 @@
 import { CborStructure, DataItem } from '@owf/cose'
 import z from 'zod'
-import { IssuerSignedItem, type IssuerSignedItemEncodedStructure } from './issuer-signed-item'
+import { IssuerSignedItem } from './issuer-signed-item'
 
 export const issuerNamespacesEncodedSchema = z.map(z.string(), z.array(z.instanceof(DataItem)))
 export const issuerNamespacesDecodedSchema = z.map(z.string(), z.array(z.instanceof(IssuerSignedItem)))
@@ -23,7 +23,7 @@ export class IssuerNamespaces extends CborStructure<
         encoded.forEach((value, key) => {
           issuerNamespaces.set(
             key,
-            value.map((isi) => IssuerSignedItem.fromEncodedStructure(isi.data as IssuerSignedItemEncodedStructure))
+            value.map((isi) => IssuerSignedItem.fromDataItem(isi))
           )
         })
 
@@ -34,7 +34,9 @@ export class IssuerNamespaces extends CborStructure<
         decoded.forEach((value, key) => {
           issuerNamespaces.set(
             key,
-            value.map((isi) => DataItem.fromData(isi.encodedStructure))
+            value.map((isi) =>
+              isi.originalEncoded ? DataItem.fromBuffer(isi.originalEncoded) : DataItem.fromData(isi.encodedStructure)
+            )
           )
         })
         return issuerNamespaces

--- a/src/mdoc/models/issuer-namespaces.ts
+++ b/src/mdoc/models/issuer-namespaces.ts
@@ -34,7 +34,16 @@ export class IssuerNamespaces extends CborStructure<
         decoded.forEach((value, key) => {
           issuerNamespaces.set(
             key,
-            value.map((isi) => DataItem.fromData(isi.encodedStructure))
+            // Forward the issuer's own bytes for items we received rather than built. A
+            // verifier digests the IssuerSignedItemBytes it is given and compares that to
+            // valueDigests, so re-encoding from the decoded structure breaks the digest for
+            // any issuer whose encoder differs from ours — the presentation side of the same
+            // problem IssuerSignedItem.isValid solves on the verification side.
+            value.map((isi) =>
+              isi.originalPayloadBytes
+                ? DataItem.fromBuffer(isi.originalPayloadBytes)
+                : DataItem.fromData(isi.encodedStructure)
+            )
           )
         })
         return issuerNamespaces

--- a/src/mdoc/models/issuer-signed-item.ts
+++ b/src/mdoc/models/issuer-signed-item.ts
@@ -1,4 +1,13 @@
-import { CborStructure, typedMap, zUint8Array } from '@owf/cose'
+import {
+  type AnyCborStructure,
+  type CborEncodeOptions,
+  CborStructure,
+  type CborStructureStaticThis,
+  cborEncode,
+  DataItem,
+  typedMap,
+  zUint8Array,
+} from '@owf/cose'
 import { compareBytes } from '@owf/identity-common'
 import { z } from 'zod'
 import type { MdocContext } from '../../context'
@@ -36,8 +45,14 @@ export class IssuerSignedItem extends CborStructure<
   IssuerSignedItemEncodedStructure,
   IssuerSignedItemDecodedStructure
 > {
+  #originalEncoded?: Uint8Array
+
   public static override get encodingSchema() {
     return issuerSignedItemSchema
+  }
+
+  public get originalEncoded() {
+    return this.#originalEncoded
   }
 
   public get random() {
@@ -54,6 +69,14 @@ export class IssuerSignedItem extends CborStructure<
 
   public get digestId() {
     return this.structure.get('digestID')
+  }
+
+  public override encode(options?: CborEncodeOptions) {
+    if (options?.asDataItem && this.#originalEncoded) {
+      return cborEncode(DataItem.fromBuffer(this.#originalEncoded))
+    }
+
+    return super.encode(options)
   }
 
   public async isValid(namespace: Namespace, issuerAuth: IssuerAuth, ctx: Pick<MdocContext, 'crypto'>) {
@@ -84,6 +107,14 @@ export class IssuerSignedItem extends CborStructure<
     }
 
     return false
+  }
+
+  public static fromDataItem<T extends AnyCborStructure>(this: CborStructureStaticThis<T>, dataItem: unknown): T {
+    const item = super.fromDataItem(dataItem) as T
+    if (item instanceof IssuerSignedItem && dataItem instanceof DataItem) {
+      item.#originalEncoded = new Uint8Array(dataItem.buffer)
+    }
+    return item
   }
 
   public static fromOptions(options: IssuerSignedItemOptions) {

--- a/src/mdoc/models/issuer-signed-item.ts
+++ b/src/mdoc/models/issuer-signed-item.ts
@@ -1,6 +1,5 @@
 import {
   type AnyCborStructure,
-  type CborEncodeOptions,
   CborStructure,
   type CborStructureStaticThis,
   cborEncode,
@@ -45,14 +44,14 @@ export class IssuerSignedItem extends CborStructure<
   IssuerSignedItemEncodedStructure,
   IssuerSignedItemDecodedStructure
 > {
-  #originalEncoded?: Uint8Array
+  #originalPayloadBytes?: Uint8Array
 
   public static override get encodingSchema() {
     return issuerSignedItemSchema
   }
 
-  public get originalEncoded() {
-    return this.#originalEncoded
+  public get originalPayloadBytes() {
+    return this.#originalPayloadBytes
   }
 
   public get random() {
@@ -71,18 +70,12 @@ export class IssuerSignedItem extends CborStructure<
     return this.structure.get('digestID')
   }
 
-  public override encode(options?: CborEncodeOptions) {
-    if (options?.asDataItem && this.#originalEncoded) {
-      return cborEncode(DataItem.fromBuffer(this.#originalEncoded))
-    }
-
-    return super.encode(options)
-  }
-
   public async isValid(namespace: Namespace, issuerAuth: IssuerAuth, ctx: Pick<MdocContext, 'crypto'>) {
     const digest = await ctx.crypto.digest({
       digestAlgorithm: issuerAuth.mobileSecurityObject.digestAlgorithm,
-      bytes: this.encode({ asDataItem: true }),
+      bytes: this.originalPayloadBytes
+        ? cborEncode(DataItem.fromBuffer(this.originalPayloadBytes))
+        : this.encode({ asDataItem: true }),
     })
 
     const valueDigests = issuerAuth.mobileSecurityObject.valueDigests.valueDigests
@@ -112,7 +105,7 @@ export class IssuerSignedItem extends CborStructure<
   public static fromDataItem<T extends AnyCborStructure>(this: CborStructureStaticThis<T>, dataItem: unknown): T {
     const item = super.fromDataItem(dataItem) as T
     if (item instanceof IssuerSignedItem && dataItem instanceof DataItem) {
-      item.#originalEncoded = new Uint8Array(dataItem.buffer)
+      item.#originalPayloadBytes = new Uint8Array(dataItem.buffer)
     }
     return item
   }

--- a/tests/models/issuer-namespaces-original-bytes.test.ts
+++ b/tests/models/issuer-namespaces-original-bytes.test.ts
@@ -1,0 +1,106 @@
+import { cborDecode, cborEncode, DataItem } from '@owf/cose'
+import { hex } from '@owf/identity-common'
+import { describe, expect, test } from 'vitest'
+import { IssuerNamespaces, IssuerSignedItem } from '../../src'
+
+const NAMESPACE = 'eu.europa.ec.eudi.pid.1'
+
+function concatBytes(...parts: Uint8Array[]) {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0))
+  let offset = 0
+  for (const part of parts) {
+    out.set(part, offset)
+    offset += part.length
+  }
+  return out
+}
+
+function cborText(value: string) {
+  const encoded = new TextEncoder().encode(value)
+  if (encoded.length >= 24) throw new Error(`text too long: ${value}`)
+  return concatBytes(Uint8Array.of(0x60 + encoded.length), encoded)
+}
+
+function cborBstr(value: Uint8Array) {
+  if (value.length >= 256) throw new Error('bstr too long')
+  return concatBytes(Uint8Array.of(0x58, value.length), value)
+}
+
+/**
+ * An `IssuerSignedItem` whose `digestID` is a 16-bit uint rather than the shortest form this
+ * library would emit. Stands in for any issuer whose CBOR encoder is not deterministic.
+ */
+function issuerSignedItemBytes() {
+  return concatBytes(
+    Uint8Array.of(0xa4),
+    cborText('digestID'),
+    Uint8Array.of(0x19, 0x00, 0x00),
+    cborText('random'),
+    cborBstr(new Uint8Array(32).fill(7)),
+    cborText('elementIdentifier'),
+    cborText('given_name'),
+    cborText('elementValue'),
+    cborText('Alice')
+  )
+}
+
+/** The `{<NAMESPACE>: [<item>]}` map as an issuer signed credential would carry it. */
+function encodedNamespaces(payload: Uint8Array) {
+  return cborEncode(new Map([[NAMESPACE, [DataItem.fromBuffer(payload)]]]))
+}
+
+function decodeNamespaces(payload: Uint8Array) {
+  return IssuerNamespaces.fromEncodedStructure(
+    cborDecode(encodedNamespaces(payload), { unwrapTopLevelDataItem: false })
+  )
+}
+
+describe('IssuerNamespaces presentation encoding', () => {
+  test('forwards the issuer bytes for items we received', () => {
+    const payload = issuerSignedItemBytes()
+    const item = decodeNamespaces(payload).getIssuerNamespace(NAMESPACE)?.[0]
+    if (!item) throw new Error('expected a decoded issuer signed item')
+
+    // Re-encoding from the decoded structure really does differ, so this is not vacuous:
+    // digestID 0x19 0x00 0x00 collapses to 0x00 and the digest stops matching valueDigests.
+    expect(hex.encode(item.encode({ asDataItem: true }))).not.toEqual(
+      hex.encode(cborEncode(DataItem.fromBuffer(payload)))
+    )
+
+    const [, items] = [...decodeNamespaces(payload).encodedStructure.entries()][0]
+    expect(hex.encode(items[0].buffer)).toEqual(hex.encode(payload))
+  })
+
+  test('a decoded credential round trips to the bytes it was decoded from', () => {
+    const payload = issuerSignedItemBytes()
+
+    expect(hex.encode(decodeNamespaces(payload).encode())).toEqual(hex.encode(encodedNamespaces(payload)))
+  })
+
+  test('disclosing a subset keeps each remaining item byte for byte', () => {
+    const payload = issuerSignedItemBytes()
+    const disclosed = decodeNamespaces(payload).getIssuerNamespace(NAMESPACE) ?? []
+
+    // limitDisclosureToDeviceRequestNameSpaces builds the presented namespaces out of the
+    // very same IssuerSignedItem instances, so the issuer bytes have to survive the rebuild.
+    const namespaces = IssuerNamespaces.create({ issuerNamespaces: new Map([[NAMESPACE, disclosed]]) })
+
+    expect(hex.encode(namespaces.encode())).toEqual(hex.encode(encodedNamespaces(payload)))
+  })
+
+  test('items we built ourselves still encode from their structure', () => {
+    const item = IssuerSignedItem.fromOptions({
+      digestId: 0,
+      random: new Uint8Array(32).fill(7),
+      elementIdentifier: 'given_name',
+      elementValue: 'Alice',
+    })
+
+    expect(item.originalPayloadBytes).toBeUndefined()
+
+    const namespaces = IssuerNamespaces.create({ issuerNamespaces: new Map([[NAMESPACE, [item]]]) })
+    expect(hex.encode(namespaces.encode())).toEqual(
+      hex.encode(cborEncode(new Map([[NAMESPACE, [DataItem.fromData(item.encodedStructure)]]])))
+    )
+  })
+})

--- a/tests/models/issuer-signed-item-original-bytes.test.ts
+++ b/tests/models/issuer-signed-item-original-bytes.test.ts
@@ -1,0 +1,91 @@
+import { cborEncode, DataItem } from '@owf/cose'
+import { hex } from '@owf/identity-common'
+import { describe, expect, test } from 'vitest'
+import { type IssuerAuth, IssuerNamespaces, IssuerSignedItem } from '../../src'
+import { mdocContext } from '../context'
+
+function concatBytes(...parts: Uint8Array[]) {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0))
+  let offset = 0
+  for (const part of parts) {
+    out.set(part, offset)
+    offset += part.length
+  }
+  return out
+}
+
+function cborText(value: string) {
+  const encoded = new TextEncoder().encode(value)
+  if (encoded.length >= 24) throw new Error(`text too long: ${value}`)
+  return concatBytes(Uint8Array.of(0x60 + encoded.length), encoded)
+}
+
+function cborBstr(value: Uint8Array) {
+  if (value.length >= 256) throw new Error('bstr too long')
+  return concatBytes(Uint8Array.of(0x58, value.length), value)
+}
+
+function createNonCanonicalPlaceOfBirthItemBytes() {
+  const random = new Uint8Array(32).fill(7)
+  const nestedMap = concatBytes(
+    Uint8Array.of(0xa2),
+    cborText('country'),
+    cborText('IT'),
+    cborText('region'),
+    cborText('Lazio')
+  )
+
+  return concatBytes(
+    Uint8Array.of(0xa4),
+    cborText('digestID'),
+    Uint8Array.of(0x19, 0x00, 0x00), // uint 0 as 16-bit; this library re-encodes as 0x00
+    cborText('random'),
+    cborBstr(random),
+    cborText('elementIdentifier'),
+    cborText('place_of_birth'),
+    cborText('elementValue'),
+    nestedMap
+  )
+}
+
+describe('IssuerSignedItem original bytes', () => {
+  test('verify and encode use received tag-24 bytes, not a re-encode', async () => {
+    const innerBytes = createNonCanonicalPlaceOfBirthItemBytes()
+    const namespaces = IssuerNamespaces.fromEncodedStructure(
+      new Map([['eu.europa.ec.eudi.pid.1', [DataItem.fromBuffer(innerBytes)]]])
+    )
+    const item = namespaces.getIssuerNamespace('eu.europa.ec.eudi.pid.1')?.[0]
+    if (!item) throw new Error('expected decoded issuer signed item')
+
+    const receivedTaggedBytes = cborEncode(DataItem.fromBuffer(innerBytes))
+    const reEncoded = IssuerSignedItem.fromOptions({
+      digestId: item.digestId,
+      random: item.random,
+      elementIdentifier: item.elementIdentifier,
+      elementValue: item.elementValue,
+    }).encode({ asDataItem: true })
+
+    const encodedItem = namespaces.encodedStructure.get('eu.europa.ec.eudi.pid.1')?.[0]
+    if (!encodedItem) throw new Error('expected encoded issuer signed item')
+
+    expect(hex.encode(reEncoded)).not.toEqual(hex.encode(receivedTaggedBytes))
+    expect(hex.encode(item.encode({ asDataItem: true }))).toEqual(hex.encode(receivedTaggedBytes))
+    expect(hex.encode(encodedItem.buffer)).toEqual(hex.encode(innerBytes))
+
+    const digest = await mdocContext.crypto.digest({
+      digestAlgorithm: 'SHA-256',
+      bytes: receivedTaggedBytes,
+    })
+
+    const issuerAuth = {
+      mobileSecurityObject: {
+        digestAlgorithm: 'SHA-256',
+        valueDigests: {
+          valueDigests: new Map([['eu.europa.ec.eudi.pid.1', new Map([[0, digest]])]]),
+        },
+      },
+    } as IssuerAuth
+
+    await expect(item.isValid('eu.europa.ec.eudi.pid.1', issuerAuth, mdocContext)).resolves.toBe(true)
+  })
+})

--- a/tests/models/issuer-signed-item-original-bytes.test.ts
+++ b/tests/models/issuer-signed-item-original-bytes.test.ts
@@ -49,7 +49,7 @@ function createNonCanonicalPlaceOfBirthItemBytes() {
 }
 
 describe('IssuerSignedItem original bytes', () => {
-  test('verify and encode use received tag-24 bytes, not a re-encode', async () => {
+  test('isValid hashes received tag-24 bytes, not a re-encode', async () => {
     const innerBytes = createNonCanonicalPlaceOfBirthItemBytes()
     const namespaces = IssuerNamespaces.fromEncodedStructure(
       new Map([['eu.europa.ec.eudi.pid.1', [DataItem.fromBuffer(innerBytes)]]])
@@ -58,19 +58,15 @@ describe('IssuerSignedItem original bytes', () => {
     if (!item) throw new Error('expected decoded issuer signed item')
 
     const receivedTaggedBytes = cborEncode(DataItem.fromBuffer(innerBytes))
-    const reEncoded = IssuerSignedItem.fromOptions({
+    const fromOptionsEncoded = IssuerSignedItem.fromOptions({
       digestId: item.digestId,
       random: item.random,
       elementIdentifier: item.elementIdentifier,
       elementValue: item.elementValue,
     }).encode({ asDataItem: true })
 
-    const encodedItem = namespaces.encodedStructure.get('eu.europa.ec.eudi.pid.1')?.[0]
-    if (!encodedItem) throw new Error('expected encoded issuer signed item')
-
-    expect(hex.encode(reEncoded)).not.toEqual(hex.encode(receivedTaggedBytes))
-    expect(hex.encode(item.encode({ asDataItem: true }))).toEqual(hex.encode(receivedTaggedBytes))
-    expect(hex.encode(encodedItem.buffer)).toEqual(hex.encode(innerBytes))
+    expect(hex.encode(fromOptionsEncoded)).not.toEqual(hex.encode(receivedTaggedBytes))
+    expect(hex.encode(item.encode({ asDataItem: true }))).not.toEqual(hex.encode(receivedTaggedBytes))
 
     const digest = await mdocContext.crypto.digest({
       digestAlgorithm: 'SHA-256',


### PR DESCRIPTION
Fixes #247

Verify hashed a re-encode of `IssuerSignedItem`. ISO 18013-5 §9.1.2.5 requires the digest over the received tag-24 bytes, so credentials from other encoders could fail `isValid`.

Keep the original inner bytes on decode. Use them for digest and namespace encode. `fromOptions` issuance still hashes a re-encode.

`DataItem.buffer` is the inner bstr, not the outer `d818` wrapper. Re-wrapping uses canonical tag-24 + shortest bstr length.